### PR TITLE
Update CI workflow to use macOS-14 and Python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-14, macos-latest]
         # python versions
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.12", "3.13"]
         
     steps:
     
@@ -56,16 +56,16 @@ jobs:
         run: |
             pip install .
 
-      - name: Install on MacOS-13
-        if: ${{ matrix.os == 'macos-13' }}
+      - name: Install on MacOS-14
+        if: ${{ matrix.os == 'macos-14' }}
         run: |
-            FC=gfortran-12 pip install .
+            FC=gfortran-14 pip install .
 
       - name: Install on MacOS-latest
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
             # https://github.com/actions/runner-images/issues/1280#issuecomment-662839485
-            FC=gfortran-12 pip install .
+            FC=gfortran-15 pip install .
             
       - name: Version info
         run: |


### PR DESCRIPTION
This pull request updates the CI workflow configuration to support newer macOS and Python versions, and ensures the correct Fortran compiler is used for each macOS runner. These changes help keep the CI pipeline up-to-date with current environments and improve compatibility.

**CI environment updates:**

* Updated the matrix to use `macos-14` instead of `macos-13`, and added Python 3.13 while removing Python 3.11.

**Compiler configuration improvements:**

* Changed the install step to use `gfortran-14` for `macos-14` and `gfortran-15` for `macos-latest`, replacing the previous `gfortran-12` configuration.